### PR TITLE
Support RandomCommand, like ConditionalCommand

### DIFF
--- a/src/parse/ast.ts
+++ b/src/parse/ast.ts
@@ -2,7 +2,7 @@ import { Token, CstNode } from './cst'
 import { getChildNode, getToken, getChildNodes } from '../treeHelpers'
 import { AstNode, Script, IfStatement, ElseIfStatement, RandomStatement, ChanceStatement, SectionStatement,
   AttributeStatement, DeclarationStatement, IncludeDrsStatement, MultilineComment,
-  CommandStatement, ConditionalCommandStatement } from './astTypes'
+  CommandStatement, ConditionalCommandStatement, RandomCommandStatement } from './astTypes'
 
 export function toAst (root: CstNode) {
   return nodeToAst(root) as Script
@@ -85,6 +85,15 @@ const astVisitorMap: { [x: string]: (node: CstNode) => AstNode } = {
     return astNode
   },
 
+  RandomCommand: (cstNode): RandomCommandStatement => {
+    const astNode = Object.assign(cstNode, {
+      type: 'RandomCommandStatement',
+      header: nodeToAst(getChildNode(cstNode, 'Random', true))
+    } as RandomCommandStatement)
+    visitCommandBody(astNode, getChildNode(cstNode, 'CommandBody', true))
+    return astNode
+  },
+
   Attribute: (cstNode): AttributeStatement => Object.assign(cstNode, {
     type: 'AttributeStatement',
     ...getNameAndArgs(cstNode)
@@ -122,7 +131,7 @@ const astVisitorMap: { [x: string]: (node: CstNode) => AstNode } = {
   } as MultilineComment)
 }
 
-function visitCommandBody (command: CommandStatement | ConditionalCommandStatement, body: CstNode) {
+function visitCommandBody (command: CommandStatement | ConditionalCommandStatement | RandomCommandStatement, body: CstNode) {
   addStatements(command, 'statements', body, true)
 
   const preCommentsContainer = getChildNode(body, 'PreCurlyComments')

--- a/src/parse/astTypes.ts
+++ b/src/parse/astTypes.ts
@@ -67,6 +67,13 @@ export interface ConditionalCommandStatement extends AstNode {
   statements?: Statement[]
 }
 
+export interface RandomCommandStatement extends AstNode {
+  type: 'RandomCommandStatement',
+  header: RandomStatement,
+  preLeftCurlyComments?: MultilineComment[],
+  statements?: Statement[]
+}
+
 export interface AttributeStatement extends AstNode {
   type: 'AttributeStatement',
   name: string,

--- a/src/parse/cst.ts
+++ b/src/parse/cst.ts
@@ -36,8 +36,8 @@ const cstVisitorMap: { [x: string]: (parts: RuleNodeChildren) => CstNode | CstNo
     for (let i = splitIndex - 1; i >= 0; i--) {
       const node = statementsBlock.children[i]
       if (isToken(node) && node.type !== 'eol') continue
-      if (!isToken(node) && ['Command', 'ConditionalCommand'].includes(node.type)) break
-      if (!isToken(node) && (getNode(node, 'Command') || getNode(node, 'ConditionalCommand'))) break
+      if (!isToken(node) && ['Command', 'ConditionalCommand', 'RandomCommand'].includes(node.type)) break
+      if (!isToken(node) && (getNode(node, 'Command') || getNode(node, 'ConditionalCommand') || getNode(node, 'RandomCommand'))) break
       splitIndex = i
     }
 

--- a/src/parse/cst.ts
+++ b/src/parse/cst.ts
@@ -65,6 +65,10 @@ const cstVisitorMap: { [x: string]: (parts: RuleNodeChildren) => CstNode | CstNo
     visitGenericIf([header]),
     nodeToCst(body as RuleNode)
   ], 'ConditionalCommand'),
+  RandomCommand: ([header, body]) => simpleCstNode([
+    visitGenericRandom([header]),
+    nodeToCst(body as RuleNode)
+  ], 'RandomCommand'),
 
   CommandBody: ([comments, ws, lcurly, statements, rcurly]) => simpleCstNode([
     simpleCstNode([comments], 'PreCurlyComments'),

--- a/src/parse/grammar.ne
+++ b/src/parse/grammar.ne
@@ -50,6 +50,7 @@ ConditionalCommand ->
   )
   CommandBody
 
+# Special kind of a command with a RandomStatement as a header instead of AttributeStatement. See #35.
 RandomCommand ->
   (
     %startRandom %eol (MultilineComment __):*

--- a/src/parse/grammar.ne
+++ b/src/parse/grammar.ne
@@ -27,7 +27,7 @@ TopLevelIf -> GenericIfSeq[TopLevelLine, Section]
 TopLevelRandom -> GenericRandomSeq[TopLevelLine, Section]
 
 Section -> %lArrow %identifier %rArrow (%eol (SectionLine %eol):* SectionLine):?
-SectionLine -> GenericWithComments[(Command | ConditionalCommand | ConstDefinition | FlagDefinition | IncludeDrs | SectionIf | SectionRandom)]
+SectionLine -> GenericWithComments[(Command | ConditionalCommand | RandomCommand | ConstDefinition | FlagDefinition | IncludeDrs | SectionIf | SectionRandom)]
 # Sections cannot be nested. Nevertheless, we allow Section to occur inside SectionIf. In that case, it's a TopLevelIf.
 # We move the `If` out of the current section and end the section here during CST traversal.
 # This seems to be the best way to avoid ambiguity and performance issues.
@@ -47,6 +47,14 @@ ConditionalCommand ->
     (%elseifToken %space %identifier __ Attribute %eol):*
     (%elseToken __ Attribute %eol):?
     %endifToken
+  )
+  CommandBody
+
+RandomCommand ->
+  (
+    %startRandom %eol (MultilineComment __):*
+    (%percentChance %space %int __ (Attribute %eol)):+
+    %endRandom
   )
   CommandBody
 

--- a/test/samples/generated/random.ast.json
+++ b/test/samples/generated/random.ast.json
@@ -192,51 +192,52 @@
       {
         "type": "SectionStatement",
         "name": "TERRAIN_GENERATION",
-        "statements": []
-      },
-      {
-        "type": "MultilineComment",
-        "comment": " Special kind of command with a RandomStatement header instead of an Attribute. "
-      },
-      {
-        "type": "RandomCommandStatement",
-        "header": {
-          "type": "RandomStatement",
-          "statements": [
-            {
-              "type": "ChanceStatement",
-              "chance": 50,
+        "statements": [
+          {
+            "type": "MultilineComment",
+            "comment": " Special kind of command with a RandomStatement header instead of an Attribute. "
+          },
+          {
+            "type": "RandomCommandStatement",
+            "header": {
+              "type": "RandomStatement",
               "statements": [
                 {
-                  "type": "AttributeStatement",
-                  "name": "create_terrain",
-                  "args": [
-                    "SNOW_FOREST"
+                  "type": "ChanceStatement",
+                  "chance": 50,
+                  "statements": [
+                    {
+                      "type": "AttributeStatement",
+                      "name": "create_terrain",
+                      "args": [
+                        "SNOW_FOREST"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ChanceStatement",
+                  "chance": 50,
+                  "statements": [
+                    {
+                      "type": "AttributeStatement",
+                      "name": "create_terrain",
+                      "args": [
+                        "FOREST"
+                      ]
+                    }
                   ]
                 }
               ]
             },
-            {
-              "type": "ChanceStatement",
-              "chance": 50,
-              "statements": [
-                {
-                  "type": "AttributeStatement",
-                  "name": "create_terrain",
-                  "args": [
-                    "FOREST"
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "statements": [
-          {
-            "type": "AttributeStatement",
-            "name": "base_terrain",
-            "args": [
-              "LEAVES"
+            "statements": [
+              {
+                "type": "AttributeStatement",
+                "name": "base_terrain",
+                "args": [
+                  "LEAVES"
+                ]
+              }
             ]
           }
         ]

--- a/test/samples/generated/random.ast.json
+++ b/test/samples/generated/random.ast.json
@@ -188,6 +188,58 @@
             ]
           }
         ]
+      },
+      {
+        "type": "SectionStatement",
+        "name": "TERRAIN_GENERATION",
+        "statements": []
+      },
+      {
+        "type": "MultilineComment",
+        "comment": " Special kind of command with a RandomStatement header instead of an Attribute. "
+      },
+      {
+        "type": "RandomCommandStatement",
+        "header": {
+          "type": "RandomStatement",
+          "statements": [
+            {
+              "type": "ChanceStatement",
+              "chance": 50,
+              "statements": [
+                {
+                  "type": "AttributeStatement",
+                  "name": "create_terrain",
+                  "args": [
+                    "SNOW_FOREST"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "ChanceStatement",
+              "chance": 50,
+              "statements": [
+                {
+                  "type": "AttributeStatement",
+                  "name": "create_terrain",
+                  "args": [
+                    "FOREST"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "statements": [
+          {
+            "type": "AttributeStatement",
+            "name": "base_terrain",
+            "args": [
+              "LEAVES"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/test/samples/random.rms
+++ b/test/samples/random.rms
@@ -37,3 +37,15 @@ start_random
   percent_chance 5
     <LAND_GENERATION>
 end_random
+
+<TERRAIN_GENERATION>
+/* Special kind of command with a RandomStatement header instead of an Attribute. */
+start_random
+  percent_chance 50
+    create_terrain SNOW_FOREST
+  percent_chance 50
+    create_terrain FOREST
+end_random
+{
+	base_terrain LEAVES
+}


### PR DESCRIPTION
Adds a `RandomCommand` AST node to represent this pattern:

```
start_random
  percent_chance 50
    create_object SCOUT
  percent_chance 50
    create_object KNIGHT
end_random
{
  /* attributes */
}
```

This pattern is used in some of HJFE's maps, like the [Melting Ice map in their Anniversary Pack](https://github.com/HJ1/Age-of-Empires-II-RMS-Maps-Archive/blob/f25128a78ad1aa6b3e21c783f038969748ee0552/AnniversaryPack(DF)_v2.1.rms#L2104-L2110) (big file).

The test fails because the linter says the `<TERRAIN_GENERATION>` section I added to the `random.rms` test file is empty, which seems wrong. However the other lint tests are the same. Should I just update the expected lint anyway?